### PR TITLE
Add clean task

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ Copy migrations to your project and execute than to create tables in your databa
 
     rake addresses:install:migrations
     rake db:migrate
+
+Run the clean task to remove all address records from your database:
+
+    rake addresses:clean

--- a/lib/tasks/addresses_tasks.rake
+++ b/lib/tasks/addresses_tasks.rake
@@ -7,3 +7,17 @@ namespace :br do
     Rake::Task['populate:countries'].invoke
   end
 end
+
+namespace :addresses do
+  desc 'Clean all address models'
+  task clean: :environment do
+    puts 'Cleaning addresses models'
+    Addresses::Address.delete_all
+    Addresses::Zipcode.delete_all
+    Addresses::Neighborhood.delete_all
+    Addresses::City.delete_all
+    Addresses::Region.delete_all
+    Addresses::State.delete_all
+    Addresses::Country.delete_all
+  end
+end


### PR DESCRIPTION
## Summary
- add `addresses:clean` rake task to purge address-related data
- document how to run the clean task in the README

## Testing
- `bundle install --local` *(fails: missing gems)*
- `bundle install` *(fails: bundler error)*
- `bundle exec rspec` *(fails: bundler error)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4da25bc832da2d5c3edab3ef8da