### PR TITLE
Fix rake index name

### DIFF
--- a/lib/tasks/populate/br/zipcodes.rake
+++ b/lib/tasks/populate/br/zipcodes.rake
@@ -15,7 +15,7 @@ module Addresses
         
         result = Addresses::Zipcode.upsert_all(
           batch,
-          unique_by: :idx_zipcodes_on_number_city_neighborhood_street,
+          unique_by: :index_addresses_zipcodes_on_number_and_city_and_neighborhood_and_street,
           update_only: []  # Let the database handle timestamps
         )
         


### PR DESCRIPTION
## Summary
- fix zipcodes rake index name to match migration

## Testing
- `bundle exec rubocop -A` *(fails: Could not find rspec-rails etc)*

------
https://chatgpt.com/codex/tasks/task_e_684eee28a940832daea4bd9324ffe4c2