### PR TITLE
Fix rake task loading for Rails 8 apps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.6.2-arm64-darwin)
+    pg (1.6.2-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -272,6 +273,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sqlite3 (2.8.0-arm64-darwin)
+    sqlite3 (2.8.0-x86_64-linux-gnu)
     stringio (3.1.0)
     thor (1.3.0)
     timeout (0.4.1)
@@ -296,6 +298,7 @@ PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
   arm64-darwin-25
+  x86_64-linux
 
 DEPENDENCIES
   addresses!

--- a/lib/addresses.rb
+++ b/lib/addresses.rb
@@ -7,5 +7,5 @@ require_relative '../app/models/addresses/country'
 require_relative '../app/services/addresses/country_data_service'
 require_relative 'addresses/country_seed_data'
 
-require 'addresses/engine' if defined?(::Rails::Engine)
-require 'addresses/railtie' if defined?(Rails)
+require 'addresses/engine'
+require 'addresses/railtie'

--- a/lib/addresses/engine.rb
+++ b/lib/addresses/engine.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rails/engine'
 require_relative 'task_loader'
 
 module Addresses

--- a/spec/lib/addresses/railtie_spec.rb
+++ b/spec/lib/addresses/railtie_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Addresses::Railtie do
+  it 'is loaded when the gem is required' do
+    expect(defined?(Addresses::Railtie)).to be_truthy
+    expect(Addresses::Railtie < Rails::Railtie).to be true
+  end
+
+  it 'exposes rake task hooks' do
+    expect(Addresses::Railtie).to respond_to(:rake_tasks)
+  end
+end


### PR DESCRIPTION
## Summary
- always require the engine and railtie so rake tasks are registered even when the gem loads before Rails boots
- ensure the engine requires `rails/engine` and add a regression spec that confirms the railtie stays loaded and exposes its task hook
- update the lockfile with the Linux platform gems that get installed in CI

## Testing
- bundle exec rspec spec/lib/addresses/railtie_spec.rb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e93be650832dac480b3107975866)